### PR TITLE
fix uninstall xdebug block for FreeBSD

### DIFF
--- a/tasks/xdebug.yml
+++ b/tasks/xdebug.yml
@@ -33,9 +33,10 @@
       state: absent
     when: ansible_os_family == 'Debian'
 
-  - name: PKGNG | Install xdebug
+  - name: PKGNG | Uninstall xdebug
     pkgng:
       name: "{{ php_xdebug_package }}"
-    when: ansible_os_family == 'FreeBSD' and php_xdebug_package is defined
+      state: absent
+    when: ansible_os_family == 'FreeBSD'
 
   when: not php_install_xdebug


### PR DESCRIPTION
This should fix the case of setting `php_install_xdebug` to **False** on FreeBSD.