### PR TITLE
fix pool.conf template in case some VARs are not defined

### DIFF
--- a/templates/etc/__php__/fpm/pool.d/pool.conf.j2
+++ b/templates/etc/__php__/fpm/pool.d/pool.conf.j2
@@ -421,13 +421,19 @@ catch_workers_output = {{ item.catch_workers_output | default('no') }}
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+{% if p.php_env is defined %}
 {% for k, v in item.php_env.items() | list %}
 env[{{ k }}] = {{ v }}
 {% endfor %}
+{% endif %}
+{% if p.php_value is defined %}
 {% for k, v in item.php_value.items() | list %}
 php_value[{{ k }}] = {{ v }}
 {% endfor %}
+{% endif %}
+{% if p.php_admin_value is defined %}
 {% for k, v in item.php_admin_value.items() | list %}
 php_admin_value[{{ k }}] = {{ v }}
 {% endfor %}
+{% endif %}
 ; vim:filetype=dosini

--- a/templates/etc/__php__/fpm/pool.d/pool.conf.j2
+++ b/templates/etc/__php__/fpm/pool.d/pool.conf.j2
@@ -421,17 +421,17 @@ catch_workers_output = {{ item.catch_workers_output | default('no') }}
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
-{% if p.php_env is defined %}
+{% if item.php_env is defined %}
 {% for k, v in item.php_env.items() | list %}
 env[{{ k }}] = {{ v }}
 {% endfor %}
 {% endif %}
-{% if p.php_value is defined %}
+{% if item.php_value is defined %}
 {% for k, v in item.php_value.items() | list %}
 php_value[{{ k }}] = {{ v }}
 {% endfor %}
 {% endif %}
-{% if p.php_admin_value is defined %}
+{% if item.php_admin_value is defined %}
 {% for k, v in item.php_admin_value.items() | list %}
 php_admin_value[{{ k }}] = {{ v }}
 {% endfor %}


### PR DESCRIPTION
VARs not defined in defaults should be processed only if they are defined (avoid `AnsibleUndefinedVariable` errors)